### PR TITLE
Fix typo in docker-compose.yml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,6 @@ Visit [Docker][docker] and get Docker up and running on your system. Optionally
 you could install [Docker Compose](docker-compose)
 to help with setting up a new container.
 
-## How to build Bugzilla Docker image
-
-To build a fresh image, just change to the directory containing the checked out
-files and run the below command:
-
-```bash
-$ docker-compose build
-```
 ## How to start Bugzilla Docker image
 
 To start a new container (or rerun your last container) you simply do:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ version: '2'
 services:
   bugzilla:
     container_name: bmo-dev
-    image: mozilla-bteam/bmo-dev
+    image: mozillabteam/bmo-dev
     ports:
       - "80:80"
       - "5900:5900"


### PR DESCRIPTION
docker-compose.yml was erroneously referring to the "mozilla-bteam" Docker
team, which should be "mozillabteam".  This resulted in an error when
trying to bring up the container.

Also fixed the docs to remove reference to building the container, since
"docker build" just reports "bugzilla uses an image, skipping".  Until this
section is updated with the proper build instructions, it should be
removed.